### PR TITLE
add wlsnarf clipboard tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ CLIPBOARD MANAGERS
 - ![Go](https://img.shields.io/badge/go-%2300add8.svg?style=plastic&logo=go&logoColor=fff) [clipman](https://github.com/chmouel/clipman) - A simple clipboard manager implementing the `wlr-data-control-unstable-v1` protocol
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [wayclip](https://github.com/noocsharp/wayclip) - A Wayland clipboard utility implementing the `wlr-data-control-unstable-v1` protocol
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [wl-clipboard](https://github.com/bugaevc/wl-clipboard) - Command-line copy/paste utilities for Wayland
-- ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [wlsnarf](https://codeberg.org/notchoc/wlsnarf) - A highly scriptable clipboard tool for wlroots-based compositors (with example filesystem-based persistent clipboard manager)
+- ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [wlsnarf](https://codeberg.org/notchoc/wlsnarf) - A highly scriptable clipboard tool for wlroots-based compositors implementing the `wlr-data-control-unstable-v1` protocol; includes a filesystem-based clipboard manager daemon with persistence
 
 COMPOSITORS
 -----------

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ CLIPBOARD MANAGERS
 - ![Go](https://img.shields.io/badge/go-%2300add8.svg?style=plastic&logo=go&logoColor=fff) [clipman](https://github.com/chmouel/clipman) - A simple clipboard manager implementing the `wlr-data-control-unstable-v1` protocol
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [wayclip](https://github.com/noocsharp/wayclip) - A Wayland clipboard utility implementing the `wlr-data-control-unstable-v1` protocol
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [wl-clipboard](https://github.com/bugaevc/wl-clipboard) - Command-line copy/paste utilities for Wayland
+- ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [wlsnarf](https://codeberg.org/notchoc/wlsnarf) - A highly scriptable clipboard tool for wlroots-based compositors (with example filesystem-based persistent clipboard manager)
 
 COMPOSITORS
 -----------


### PR DESCRIPTION
DESCRIPTION
===========

[wlsnarf](https://codeberg.org/notchoc/wlsnarf)

wlsnarf is a highly extensible clipboard tool
snarfsrv (in the same repo) is an example filesystem-based clipboard manager

CHECKLIST
---------

I have:
- [X] 🤳 made sure that what I am adding is **targeted** for Wayland.
- [X] 🔗 checked that the link I am using refers to the source repository.
- [X] 📝 checked that the projects and/or the sections are alphabetically sorted.
