### PR TITLE
Added haruhishot

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ SCREENSHOTS
 
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [dulcepan](https://codeberg.org/vyivel/dulcepan) - A screenshot tool for wlroots-based Wayland compositors, implementing the `wlr-layer-shell-unstable-v1` and `wlr-screencopy-unstable-v1` protocols
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [grim](https://git.sr.ht/~emersion/grim) - Grab images from a Wayland compositor
+- ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [haruhishot](https://github.com/Decodetalkers/haruhishot) - It is a screenshot tool for wlroots based compositors such as sway and river written in Rust, with wayland-rs
 - ![Go](https://img.shields.io/badge/go-%2300add8.svg?style=plastic&logo=go&logoColor=fff) [samurai-select](https://github.com/Samudevv/samurai-select) - A screen selection tool for wlroots-based Wayland compositors implementing `wlr-layer-shell-unstable-v1`
 - ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [Satty](https://github.com/gabm/Satty) - A screenshot annotation tool inspired by Swappy and Flameshot
 - ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [shotman](https://git.sr.ht/~whynothugo/shotman) - A screenshot GUI for Wayland compositors implementing `wlr-layer-shell-unstable-v1`, `wlr-screencopy-unstable-v1`, and `single-pixel-buffer-v1` protocols


### PR DESCRIPTION
DESCRIPTION
===========

[haruhishot] (https://github.com/Decodetalkers/haruhishot)

It is a screenshot tool for wlroots based compositors such as sway and river written in Rust, with wayland-rs.

CHECKLIST
---------

I have:
- [✓] 🤳 made sure that what I am adding is **targeted** for Wayland.
- [✓] 🔗 checked that the link I am using refers to the source repository.
- [✓] 📝 checked that the projects and/or the sections are alphabetically sorted.