### PR TITLE
add fht-compositor entry to compositors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ COMPOSITORS
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [croissant](https://codeberg.org/vyivel/croissant) - A wlroots-based stacking Wayland compositor
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [CwC](https://github.com/Cudiph/cwcwm) - A highly configurable wlroots-based tiling window manager, inspired by AwesomeWM
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [dwl](https://codeberg.org/dwl/dwl) - A wlroots-based rewrite of DWM for Wayland
+- ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [fht-compositor](https://github.com/nferhat/fht-compositor) - A dynamic tiling Wayland compositor
 - ![Zig](https://img.shields.io/badge/zig-%23f7a41d.svg?style=plastic&logo=zig&logoColor=fff) [foxwhale](https://github.com/malcolmstill/foxwhale) - A tiling Wayland compositor based on wlroots
 - ![Python](https://img.shields.io/badge/python-4584b6?style=plastic&logo=python&logoColor=ffde57) [Gabbia](https://github.com/heuer/gabbia) - A Wayland compositor inspired by Cage that runs a single application in maximized mode, particularly suitable for kiosk applications
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [gamescope](https://github.com/ValveSoftware/gamescope) - A wlroots-based Wayland compositor designed for SteamOS


### PR DESCRIPTION
DESCRIPTION
===========

[fht-compositor](https://github.com/nferhat/fht-compositor)

 A dynamic tiling Wayland compositor

CHECKLIST
---------

I have:
- [x] 🤳 made sure that what I am adding is **targeted** for Wayland.
- [x] 🔗 checked that the link I am using refers to the source repository.
- [x] 📝 checked that the projects and/or the sections are alphabetically sorted.
