### PR TITLE
LabFyre + Dotool

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ COMPOSITORS
 - ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [Jay](https://github.com/mahkoh/jay) - A tiling Wayland compositor inspired by i3wm
 - ![Go](https://img.shields.io/badge/go-%2300add8.svg?style=plastic&logo=go&logoColor=fff) [kawa](https://github.com/DeedleFake/kawa) - A wlroots-based Wayland compositor inspired by Plan 9's Rio
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [kiwmi](https://github.com/buffet/kiwmi) - A fully programmable Wayland compositor
-- ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [LabFyre](https://github.com/FyreX-opensource-design/labFyre) - A Wayland window-stacking and tiling compositor that doesn't sacrifice modularity
+- ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [LabFyre](https://github.com/FyreX-opensource-design/labFyre) - A wlroots-based modular stacking and tiling Wayland compositor, forked from labwc
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [labwc](https://github.com/labwc/labwc) - A wlroots-based stacking compositor for Wayland, inspired by openbox
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [LaikaWM](https://github.com/ianmartinez/laikawm) - A lightweight compositor for Wayland inspired by IceWM and Fluxbox
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [Liri Shell](https://github.com/lirios/shell) - A convergent shell for desktops, phones, and tablets
@@ -321,7 +321,6 @@ TOOLS
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [clipcell](https://github.com/divadiahim/clipcell) - A clipboard manager with support for text and image preview for wlroots-based Wayland compositors implementing the `wlr-layer-shell-unstable-v1` protocol
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [dd99 Wayland Library](https://github.com/Delta-dev-99/dd99_wayland) - A Wayland protocol scanner
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [Door Knocker](https://codeberg.org/tytan652/door-knocker) - A simple tool to check the availability of XDG portals in a running session
-- ![Go](https://img.shields.io/badge/go-%2300add8.svg?style=plastic&logo=go&logoColor=fff) [dotool](https://sr.ht/~geb/dotool/) - dotool reads actions from stdin and simulates keyboard/mouse input using Linux's uinput module. It works systemwide and supports keyboard layouts.
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [hyprpicker](https://github.com/hyprwm/hyprpicker) - A wlroots-compatible Wayland color picker
 - ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [lan-mouse](https://github.com/feschber/lan-mouse) - A mouse and keyboard sharing software
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [lswt](https://git.sr.ht/~leon_plickat/lswt) - List Wayland toplevels in both human readable and machine parsable formats via the `wlr-foreign-toplevel-management-unstable-v1` protocol


### PR DESCRIPTION
DESCRIPTION
===========

[LabFyre](https://github.com/FyreX-opensource-design/labFyre)

LabFyre is a stacking + tiling compositor that's meant to allow for heavy scripting, but light by itself

[dotool](https://git.sr.ht/~geb/dotool)

dotool is a Desktop agnostic input util that works system wide (works in TTY and X11 as well as Wayland)

actual descriptions are taken from the respective repos


CHECKLIST
---------

I have:
- [Y] 🤳 made sure that what I am adding is **targeted** for Wayland.
- [Y] 🔗 checked that the link I am using refers to the source repository.
- [Y] 📝 checked that the projects and/or the sections are alphabetically sorted.
