### PR TITLE
Add tinct to THEMING

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ THEMING
 -------
 
 - ![Go](https://img.shields.io/badge/go-%2300add8.svg?style=plastic&logo=go&logoColor=fff) [nwg-look](https://github.com/nwg-piotr/nwg-look) - A GTK 3 settings editor designed to work properly in a wlroots-based environment
+- ![Go](https://img.shields.io/badge/go-%2300add8.svg?style=plastic&logo=go&logoColor=fff) [tinct](https://github.com/jmylchreest/tinct) - A plugin-based theme/templating tool inspired by Pywal and Matugen with multiple input mechanisms
 
 TOOLS
 -----


### PR DESCRIPTION
[tinct](https://github.com/jmylchreest/tinct) is a Pywal/Matugen-style theme generator and templating tool (Go).

* Plugin-based: multiple input mechanisms (wallpapers, hex codes, image URLs, time-of-day) all feed the same templating engine.
* Generates colour palettes and renders templates for any consumer that needs them — terminals, status bars, OSDs, GTK / Qt themes, etc.
* Pairs naturally with wallpaper daemons (swww, hyprpaper) and notification daemons that read theme palettes from disk.

Inserted alphabetically after \`nwg-look\`.