### PR TITLE
Add CrossMacro

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ TOOLS
 -----
 
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [clipcell](https://github.com/divadiahim/clipcell) - A clipboard manager with support for text and image preview for wlroots-based Wayland compositors implementing the `wlr-layer-shell-unstable-v1` protocol
+- ![C#](https://img.shields.io/badge/c%23-%23512bd4.svg?style=plastic&logo=csharp&logoColor=fff) [CrossMacro](https://github.com/alper-han/CrossMacro) - A cross-platform macro recorder, player, editor, and text expansion tool with Wayland and X11 support on Linux
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [dd99 Wayland Library](https://github.com/Delta-dev-99/dd99_wayland) - A Wayland protocol scanner
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [Door Knocker](https://codeberg.org/tytan652/door-knocker) - A simple tool to check the availability of XDG portals in a running session
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [hyprpicker](https://github.com/hyprwm/hyprpicker) - A wlroots-compatible Wayland color picker


### PR DESCRIPTION
[CrossMacro](https://github.com/alper-han/CrossMacro)

CrossMacro is a cross-platform macro recorder and player with a macro editor, text expansion support, and Linux support for both Wayland and X11.