### PR TITLE
Add yeet to Launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ LAUNCHERS
 - ![Python](https://img.shields.io/badge/python-4584b6?style=plastic&logo=python&logoColor=ffde57) [waypiedock](https://gitlab.com/Arnaudv6/waypiedock) - A launcher dock, in the shape of a pie, under the mouse
 - ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [wldash](https://github.com/kennylevinsen/wldash) - A dashboard, launcher, or control panel for Wayland, using the `wlr-layer-shell-unstable-v1` protocol
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [wmenu](https://codeberg.org/adnano/wmenu) - A dynamic menu for Sway and wlroots-based compositors inspired by dmenu
+- ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [yeet](https://github.com/1337hero/yeet) - A fast, minimal, and configurable application launcher for Wayland compositors implementing the `gtk4-layer-shell` protocol
 - ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [yofi](https://github.com/l4l/yofi) - A minimalistic menu for Wayland-based compositors
 
 LIBRARIES


### PR DESCRIPTION
Adds [yeet](https://github.com/1337hero/yeet) — a fast, minimal, configurable application launcher for Wayland (Rust + GTK4, `gtk4-layer-shell`). Fuzzy search with launch-history ranking, TOML/CSS config, and a dmenu mode (`yeet --dmenu`).

Placed alphabetically before yofi, matching the existing badge/description format.

![yeet screenshot](https://raw.githubusercontent.com/1337hero/yeet/main/yeet.png)
