### PR TITLE
Add steppewm to COMPOSITORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ COMPOSITORS
 - ![Zig](https://img.shields.io/badge/zig-%23f7a41d.svg?style=plastic&logo=zig&logoColor=fff) [river](https://codeberg.org/river/river) - A non-monolithic Wayland compositor
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [scroll](https://github.com/dawsers/scroll) - A wlroots-based scrollable Wayland compositor forked from sway with a layout similar to PaperWM and niri
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [stagen](https://github.com/lidgnulinux/stagen) - An experimental wlroots-based Wayland compositor
+- ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [steppewm](https://github.com/uncognic/steppewm) - A minimal IceWM-like stacking Wayland compositor
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [SwayFX](https://github.com/wlrfx/swayfx) - Sway, but with eye candy
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [sway](https://github.com/swaywm/sway) - An i3-compatible Wayland compositor
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [tiley](https://github.com/creamIcec/tiley) - A customizable tiling Wayland compositor based on Louvre

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ COMPOSITORS
 - ![Zig](https://img.shields.io/badge/zig-%23f7a41d.svg?style=plastic&logo=zig&logoColor=fff) [river](https://codeberg.org/river/river) - A non-monolithic Wayland compositor
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [scroll](https://github.com/dawsers/scroll) - A wlroots-based scrollable Wayland compositor forked from sway with a layout similar to PaperWM and niri
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [stagen](https://github.com/lidgnulinux/stagen) - An experimental wlroots-based Wayland compositor
-- ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [steppewm](https://github.com/uncognic/steppewm) - A minimal IceWM-like stacking Wayland compositor
+- ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [steppewm](https://github.com/uncognic/steppewm) - A minimal stacking wlroots-based Wayland compositor inspired by IceWM
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [SwayFX](https://github.com/wlrfx/swayfx) - Sway, but with eye candy
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [sway](https://github.com/swaywm/sway) - An i3-compatible Wayland compositor
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [tiley](https://github.com/creamIcec/tiley) - A customizable tiling Wayland compositor based on Louvre


### PR DESCRIPTION
DESCRIPTION
===========
[steppewm](https://github.com/uncognic/steppewm)

A minimal IceWM-like stacking Wayland compositor

CHECKLIST
---------

I have:
- [x ] 🤳 made sure that what I am adding is **targeted** for Wayland **without** relying on another Wayland-based application.
- [x ] 🔗 checked that the link I am using refers to the source repository.
- [x ] 📝 checked that the projects and/or the sections are alphabetically sorted.
