### PR TITLE
Add deskwright to TOOLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ TOOLS
 
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [clipcell](https://github.com/divadiahim/clipcell) - A clipboard manager with support for text and image preview for wlroots-based Wayland compositors implementing the `wlr-layer-shell-unstable-v1` protocol
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [dd99 Wayland Library](https://github.com/Delta-dev-99/dd99_wayland) - A Wayland protocol scanner
+- ![Python](https://img.shields.io/badge/python-4584b6?style=plastic&logo=python&logoColor=ffde57) [deskwright](https://github.com/tristanmuzzu/deskwright) - An MCP server that lets an AI agent drive a GNOME/Wayland desktop through AT-SPI, `org.gnome.Mutter.RemoteDesktop` and `xdg-desktop-portal`, optionally on a second headless session on a virtual monitor
 - ![C](https://img.shields.io/badge/c-%23044f88.svg?style=plastic&logo=c&logoColor=fff) [Door Knocker](https://codeberg.org/tytan652/door-knocker) - A simple tool to check the availability of XDG portals in a running session
 - ![C++](https://img.shields.io/badge/c++-%235e97d0.svg?style=plastic&logo=c%2B%2B&logoColor=fff) [hyprpicker](https://github.com/hyprwm/hyprpicker) - A wlroots-compatible Wayland color picker
 - ![Rust](https://img.shields.io/badge/rust-%23281c1c.svg?style=plastic&logo=rust&logoColor=fff) [lan-mouse](https://github.com/feschber/lan-mouse) - A mouse and keyboard sharing software


### PR DESCRIPTION
Adds [deskwright](https://github.com/tristanmuzzu/deskwright), inserted alphabetically in TOOLS.

It lets an AI agent operate a GNOME/Wayland desktop: AT-SPI for the accessibility tree, `org.gnome.Mutter.RemoteDesktop` for pointer and keyboard, `xdg-desktop-portal` as the cross-compositor input route, and a small shell extension for the parts gnome-shell keeps to itself. It can also run on a second headless GNOME session on a virtual monitor.

On scope: it is designed for Wayland rather than ported to it. It exists because Wayland denies screenshots, global input and window control to ordinary clients, and every mechanism it uses is a Wayland-era one. There is no X11 path.

Apache-2.0, Python, on PyPI as `deskwright`, and listed in the official MCP registry.